### PR TITLE
Rename SGD scraper and add docs

### DIFF
--- a/.github/workflows/sgd.yml
+++ b/.github/workflows/sgd.yml
@@ -34,4 +34,4 @@ jobs:
           pip install requests beautifulsoup4 lxml datasets tqdm
 
       - name: Run scraper
-        run: python main.py
+        run: python crawler_for_sgd.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Statengeneraal Digitaal scraper
+
+This repository contains a crawler that collects OCR XML text from the
+[Statengeneraal Digitaal](https://repository.overheid.nl/frbr/sgd) portal and
+pushes the plain text to a Hugging Face dataset.
+
+## Usage
+
+The script is intended to run from GitHub Actions. Configure the following
+environment variables:
+
+- `HF_TOKEN` – Hugging Face token with write access.
+- `HF_DATASET_REPO` – destination dataset repository (e.g. `my-org/sgd-ocr`).
+- `HF_PRIVATE` – optional `true`/`false` to create a private dataset.
+
+Run the crawler locally or inside the workflow:
+
+```bash
+python crawler_for_sgd.py
+```
+
+See `.github/workflows/sgd.yml` for a complete example.
+
+## Dependencies
+
+The workflow installs these Python packages: `requests`, `beautifulsoup4`,
+`lxml`, `datasets` and `tqdm`.

--- a/crawler_for_sgd.py
+++ b/crawler_for_sgd.py
@@ -1,17 +1,18 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
+"""crawler_for_sgd.py
+
 Crawl Statengeneraal Digitaal (https://repository.overheid.nl/frbr/sgd)
 and push OCR XML text to a Hugging Face dataset.
 
-Designed to run *only* inside GitHub Actions.  
-Requires the following environment variables:
+Designed to run *only* inside GitHub Actions. Requires the following
+environment variables:
 
 - HF_TOKEN          – Hugging Face token with write access
 - HF_DATASET_REPO   – e.g. "my-org/sgd-ocr"
 - HF_PRIVATE        – "true" or "false" (optional; default false)
 
-Dependencies (installed in the workflow):
+Dependencies are installed in the workflow:
   requests, beautifulsoup4, lxml, datasets, tqdm
 """
 


### PR DESCRIPTION
## Summary
- rename the main scraper to `crawler_for_sgd.py`
- update GitHub Actions workflow to use the new name
- add a README with basic usage instructions
- add an MIT license

## Testing
- `python -m py_compile crawler_for_sgd.py`

------
https://chatgpt.com/codex/tasks/task_e_685a8d492bac832999c30efbf64408a8