### PR TITLE
Add limit to SGD scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Run the crawler locally or inside the workflow:
 python crawler_for_sgd.py
 ```
 
+The script is intentionally limited to processing at most 500 OCR XML files per
+run to avoid long execution times in CI environments.
+
 See `.github/workflows/sgd.yml` for a complete example.
 
 ## Dependencies


### PR DESCRIPTION
## Summary
- cap the Statengeneraal Digitaal crawl to 500 items
- document the limit in the README

## Testing
- `python -m py_compile crawler_for_sgd.py`

------
https://chatgpt.com/codex/tasks/task_e_685a8f64503c8329a0122251a7ebb276