### PR TITLE
Improve crawler efficiency with generators and ZIP downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ python crawler_for_sgd.py
 The script is intentionally limited to processing at most 500 OCR XML files per
 run to avoid long execution times in CI environments.
 
+OCR data is retrieved via the service's ZIP archives when possible to minimise
+the number of HTTP requests.
+
 See `.github/workflows/sgd.yml` for a complete example.
 
 ## Dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
 lxml
 beautifulsoup4
-huggingface_hub
+datasets
+tqdm


### PR DESCRIPTION
## Summary
- stream discovery of subareas and documents with generators
- fetch OCR data using zip archives when available
- update requirements to match used packages
- mention zip usage in README
- fix type hints for the record generator

## Testing
- `python -m py_compile crawler_for_sgd.py`

------
https://chatgpt.com/codex/tasks/task_e_685ae14b371083299a349924e34ed816