### PR TITLE
Enable scheduled scraping

### DIFF
--- a/.github/workflows/sgd.yml
+++ b/.github/workflows/sgd.yml
@@ -1,12 +1,14 @@
 name: Scrape Statengeneraal Digitaal OCR
 
 on:
+  schedule:
+    - cron: "*/30 * * * *"
   workflow_dispatch:
     inputs:
       hf_repo:
         description: "Target Hugging Face dataset repo (e.g. username/sgd-ocr)"
         required: true
-        default: "username/sgd-ocr"
+        default: "vGassen/Dutch-Statengeneraal-Digitaal-Historical"
       private:
         description: "Make the dataset private? (true/false)"
         required: false
@@ -17,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}          # <-- add this secret in repo settings
-      HF_DATASET_REPO: ${{ github.event.inputs.hf_repo }}
-      HF_PRIVATE: ${{ github.event.inputs.private }}
+      HF_DATASET_REPO: ${{ github.event.inputs.hf_repo || 'vGassen/Dutch-Statengeneraal-Digitaal-Historical' }}
+      HF_PRIVATE: ${{ github.event.inputs.private || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,5 +35,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install requests beautifulsoup4 lxml datasets tqdm
 
+      - name: Restore progress
+        uses: actions/cache@v4
+        with:
+          path: visited.txt
+          key: visited-${{ github.run_id }}
+          restore-keys: visited-
+
       - name: Run scraper
-        run: python crawler_for_sgd.py
+        run: python crawler_for_sgd.py --resume

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ between requests.
 OCR data is retrieved via the service's ZIP archives when possible to minimise
 the number of HTTP requests.
 
+The included GitHub workflow runs every 30 minutes and keeps track of processed
+files using a cached `visited.txt`. Results are uploaded to the public dataset
+`vGassen/Dutch-Statengeneraal-Digitaal-Historical`.
+
 See `.github/workflows/sgd.yml` for a complete example.
 
 ## Dependencies


### PR DESCRIPTION
## Summary
- schedule runs every 30 minutes and keep resume info via cache
- default HF dataset to `vGassen/Dutch-Statengeneraal-Digitaal-Historical`
- update README with cron details

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_685af6d02e18832986340258257d30c6