### PR TITLE
Add argparse and resume functionality

### DIFF
--- a/.github/workflows/sgd-crawler.yml
+++ b/.github/workflows/sgd-crawler.yml
@@ -29,8 +29,15 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Restore crawl cache
+        uses: actions/cache@v3
+        with:
+          path: visited.txt
+          key: visited-${{ github.run_id }}
+          restore-keys: visited-
+
       - name: Run crawler script
-        run: python scripts/sgd_crawler.py
+        run: python scripts/sgd_crawler.py --resume
 
       - name: Commit and push changes
         run: |

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ the workflow from hanging indefinitely when the server is unresponsive.
 OCR data is retrieved via the service's ZIP archives when possible to minimise
 the number of HTTP requests.
 
-The included GitHub workflow runs every 30 minutes and keeps track of processed
-files using a cached `visited.txt`. Results are uploaded to the public dataset
+The included GitHub workflow runs daily and keeps track of processed files
+using a cached `visited.txt`. Results are uploaded to the public dataset
 `vGassen/Dutch-Statengeneraal-Digitaal-Historical`.
 
 See `.github/workflows/sgd.yml` for a complete example.

--- a/tests/test_sgd_crawler.py
+++ b/tests/test_sgd_crawler.py
@@ -1,0 +1,80 @@
+import io
+import json
+import zipfile
+
+import pytest
+
+import scripts.sgd_crawler as crawler
+
+
+class MockResponse:
+    def __init__(self, content):
+        self.content = content.encode("utf-8") if isinstance(content, str) else content
+
+    def raise_for_status(self):
+        pass
+
+
+def test_get_year_links(monkeypatch):
+    html = "<a href='1999/'>1999</a><a href='foo'>foo</a><a href='2000/'>2000</a>"
+
+    def mock_get(url, headers=None):
+        return MockResponse(html)
+
+    monkeypatch.setattr(crawler.requests, "get", mock_get)
+    years = crawler.get_year_links()
+    assert years == [f"{crawler.BASE_URL}/1999/", f"{crawler.BASE_URL}/2000/"]
+
+
+def test_get_work_links(monkeypatch):
+    html = "<a href='123/'>123</a><a href='bar'>bar</a><a href='456/'>456</a>"
+
+    def mock_get(url, headers=None):
+        return MockResponse(html)
+
+    monkeypatch.setattr(crawler.requests, "get", mock_get)
+    works = crawler.get_work_links("https://example.com/1999/")
+    assert works == ["https://example.com/1999/123/", "https://example.com/1999/456/"]
+
+
+def test_process_work(monkeypatch):
+    xml_content = "<root><p>Hello</p></root>"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("ocr/test.xml", xml_content)
+
+    def mock_get(url, headers=None, stream=True):
+        return MockResponse(buf.getvalue())
+
+    monkeypatch.setattr(crawler.requests, "get", mock_get)
+    docs = crawler.process_work("https://example.com/work/1/")
+    assert docs[0]["content"] == "Hello"
+
+
+def test_push_batches_to_hub(monkeypatch, tmp_path):
+    data = {"URL": "u", "content": "c", "source": "s"}
+    batch = tmp_path / "batch.jsonl"
+    with open(batch, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+        f.write("\n")
+
+    pushed = {}
+
+    class DummyDS:
+        def __init__(self, *args, **kwargs):
+            pass
+        
+        def push_to_hub(self, *args, **kwargs):
+            pushed["called"] = True
+
+        def __len__(self):
+            return 1
+
+    monkeypatch.setattr(crawler, "Dataset", DummyDS)
+    monkeypatch.setattr(crawler, "concatenate_datasets", lambda x: DummyDS())
+    monkeypatch.setattr(crawler, "Features", lambda *a, **k: None)
+    monkeypatch.setattr(crawler, "Value", lambda *a, **k: None)
+
+    assert crawler.push_batches_to_hub([str(batch)])
+    assert pushed.get("called")
+


### PR DESCRIPTION
## Summary
- implement `argparse` options and resume support in `sgd_crawler.py`
- track visited works using a `visited.txt` cache
- improve error handling when pushing to HuggingFace
- document new flags and caching in README
- update workflow to restore cache and run crawler with `--resume`
- add unit tests for the crawler helpers

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685ea70119b08329a555f3c8c8ca1c6b